### PR TITLE
feat: add solution/editorial system and optimize judge performance

### DIFF
--- a/backend/internal/model/problem.go
+++ b/backend/internal/model/problem.go
@@ -13,6 +13,12 @@ type Problem struct {
 	IsVipOnly          bool            `gorm:"column:is_vip_only" json:"is_vip_only"`
 	IsACMMode          bool            `gorm:"column:is_acm_mode" json:"is_acm_mode"`
 	TestCases          json.RawMessage `gorm:"column:test_cases;type:json" json:"test_cases"`
+	TimeLimitMs        int             `gorm:"column:time_limit_ms;default:0" json:"time_limit_ms"`
+	MemoryLimitMB      int             `gorm:"column:memory_limit_mb;default:0" json:"memory_limit_mb"`
+	IsSpj              bool            `gorm:"column:is_spj;default:false" json:"is_spj"`
+	JudgeEnabled       bool            `gorm:"column:judge_enabled;default:true" json:"judge_enabled"`
+	Solutions          json.RawMessage `gorm:"column:solutions;type:json" json:"solutions"`
+	Editorial          *string         `gorm:"column:editorial;type:mediumtext" json:"editorial"`
 }
 
 // ProblemListItem 是列表接口的轻量响应 DTO，不含大字段 content 和 template_code

--- a/backend/internal/sandbox/container_pool.go
+++ b/backend/internal/sandbox/container_pool.go
@@ -1,0 +1,431 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ContainerPool manages long-running Docker containers that are reused across
+// executions. Instead of `docker run --rm` per task, we `docker exec` into
+// persistent containers — eliminating container startup overhead (~1-2s per run).
+//
+// Architecture:
+//   - One pool per Docker image (e.g. gatecode-judge:latest, node-ts:20)
+//   - Each pool has N containers (configurable via PoolSize)
+//   - Callers acquire a container, run commands via docker exec, then release
+//   - Containers are created lazily on first use and restarted if they die
+
+// PoolSize controls how many containers per image. Set higher for more parallelism.
+var PoolSize = 8
+
+// poolEntry is a single persistent container in the pool.
+type poolEntry struct {
+	name string // docker container name
+	mu   sync.Mutex
+}
+
+// imagePool holds containers for a single Docker image.
+type imagePool struct {
+	image   string
+	memMB   int
+	entries []*poolEntry
+	sem     chan int // semaphore: available entry indices
+	mu      sync.Mutex
+	started bool
+}
+
+var (
+	pools   = make(map[string]*imagePool)
+	poolsMu sync.Mutex
+	poolSeq atomic.Int64
+)
+
+// getPool returns (or creates) the container pool for the given image.
+func getPool(image string, memMB int) *imagePool {
+	poolsMu.Lock()
+	defer poolsMu.Unlock()
+	if p, ok := pools[image]; ok {
+		return p
+	}
+	p := &imagePool{
+		image: image,
+		memMB: memMB,
+		sem:   make(chan int, PoolSize),
+	}
+	pools[image] = p
+	return p
+}
+
+// ensureStarted lazily creates all containers in the pool.
+func (p *imagePool) ensureStarted() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return
+	}
+
+	p.entries = make([]*poolEntry, PoolSize)
+	for i := 0; i < PoolSize; i++ {
+		name := fmt.Sprintf("gc_pool_%s_%d_%d", sanitizeImageName(p.image), poolSeq.Add(1), i)
+		p.entries[i] = &poolEntry{name: name}
+		if err := startContainer(name, p.image, p.memMB); err != nil {
+			log.Printf("[pool] WARNING: failed to start container %s: %v", name, err)
+		}
+		p.sem <- i // mark slot as available
+	}
+	// Brief pause to let Docker fully start all containers
+	time.Sleep(500 * time.Millisecond)
+	p.started = true
+	log.Printf("[pool] Started %d containers for image %s", PoolSize, p.image)
+}
+
+// acquire blocks until a container slot is available, returns its index.
+func (p *imagePool) acquire() int {
+	p.ensureStarted()
+	return <-p.sem
+}
+
+// release returns a container slot to the pool.
+func (p *imagePool) release(idx int) {
+	p.sem <- idx
+}
+
+// startContainer creates and starts a persistent Docker container.
+func startContainer(name, image string, memMB int) error {
+	// Kill any leftover container with the same name
+	exec.Command("docker", "rm", "-f", name).Run()
+
+	args := []string{
+		"run", "-d",
+		"--name", name,
+		"--network", "none",
+		fmt.Sprintf("--memory=%dm", memMB),
+		fmt.Sprintf("--memory-swap=%dm", memMB),
+		"--cpus=1",
+		"--pids-limit=256",
+		"--ulimit", "nofile=256:256",
+		"--ulimit", fmt.Sprintf("fsize=%d:%d", 64<<20, 64<<20),
+		// tmpfs /tmp for compiled artefacts (in-memory, fast)
+		// /w is a regular directory (created in Dockerfile) so docker cp works
+		"--tmpfs", "/tmp:rw,exec,nodev,nosuid,size=64m",
+		image,
+		"sleep", "infinity",
+	}
+
+	cmd := exec.Command("docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker run: %w: %s", err, stderr.String())
+	}
+
+	// Wait for container to be running (up to 5s)
+	for i := 0; i < 10; i++ {
+		if isContainerRunning(name) {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	// Check why it's not running
+	logsOut, _ := exec.Command("docker", "logs", "--tail", "5", name).CombinedOutput()
+	return fmt.Errorf("container %s started but not running after 5s, logs: %s", name, string(logsOut))
+}
+
+// restartContainer kills and re-creates a container.
+func restartContainer(entry *poolEntry, image string, memMB int) error {
+	exec.Command("docker", "rm", "-f", entry.name).Run()
+	time.Sleep(100 * time.Millisecond)
+	return startContainer(entry.name, image, memMB)
+}
+
+// sanitizeImageName converts an image name to a safe string for container naming.
+func sanitizeImageName(image string) string {
+	r := strings.NewReplacer(":", "_", "/", "_", ".", "_")
+	return r.Replace(image)
+}
+
+// containerHandle is returned by AcquireContainer and must be released after use.
+// It allows multiple docker exec calls in the same container (needed for judge:
+// compile once, then run N test cases).
+type containerHandle struct {
+	pool  *imagePool
+	idx   int
+	entry *poolEntry
+}
+
+// Name returns the Docker container name.
+func (h *containerHandle) Name() string {
+	return h.entry.name
+}
+
+// Release returns the container to the pool.
+func (h *containerHandle) Release() {
+	h.entry.mu.Unlock()
+	h.pool.release(h.idx)
+}
+
+// AcquireContainer gets a container from the pool for the given image.
+// The caller MUST call handle.Release() when done.
+// Optimized: skips docker inspect health check (saves ~25ms per acquire).
+// Instead, CopyToContainer/ExecInContainer will detect dead containers.
+func AcquireContainer(image string, memMB int) *containerHandle {
+	pool := getPool(image, memMB)
+	idx := pool.acquire()
+	entry := pool.entries[idx]
+	entry.mu.Lock()
+	return &containerHandle{pool: pool, idx: idx, entry: entry}
+}
+
+// EnsureContainerHealthy checks and restarts the container if needed.
+// Called lazily on first failure rather than on every acquire.
+func EnsureContainerHealthy(h *containerHandle, image string, memMB int) {
+	if !isContainerRunning(h.entry.name) {
+		log.Printf("[pool] Container %s not running, restarting...", h.entry.name)
+		if err := restartContainer(h.entry, image, memMB); err != nil {
+			log.Printf("[pool] ERROR restarting container %s: %v", h.entry.name, err)
+		}
+	}
+}
+
+// CopyToContainer copies files from hostDir to /w inside the container.
+// Includes chmod + cleanup in a separate docker exec call.
+func CopyToContainer(cname, hostDir string) error {
+	copyCmd := exec.Command("docker", "cp", hostDir+"/.", cname+":/w/")
+	var copyErr bytes.Buffer
+	copyCmd.Stderr = &copyErr
+	if err := copyCmd.Run(); err != nil {
+		return fmt.Errorf("docker cp: %w: %s", err, copyErr.String())
+	}
+
+	exec.Command("docker", "exec", "-u", "root", cname, "sh", "-c",
+		"chmod -R 755 /w; rm -rf /tmp/_in_* /tmp/_out_* /tmp/_err_* 2>/dev/null; true").Run()
+	return nil
+}
+
+// CopyToContainerFast copies files with ONLY docker cp — no extra exec.
+// The runner script itself handles chmod. Saves ~130ms per judge call.
+func CopyToContainerFast(cname, hostDir string) error {
+	copyCmd := exec.Command("docker", "cp", hostDir+"/.", cname+":/w/")
+	var copyErr bytes.Buffer
+	copyCmd.Stderr = &copyErr
+	if err := copyCmd.Run(); err != nil {
+		return fmt.Errorf("docker cp: %w: %s", err, copyErr.String())
+	}
+	return nil
+}
+
+// CopyFileToContainer copies a single file from host to a path inside the container.
+func CopyFileToContainer(cname, hostPath, containerPath string) error {
+	copyCmd := exec.Command("docker", "cp", hostPath, cname+":"+containerPath)
+	var copyErr bytes.Buffer
+	copyCmd.Stderr = &copyErr
+	if err := copyCmd.Run(); err != nil {
+		return fmt.Errorf("docker cp: %w: %s", err, copyErr.String())
+	}
+	// Fix permissions on the copied file
+	exec.Command("docker", "exec", "-u", "root", cname, "sh", "-c",
+		fmt.Sprintf("chmod 644 %s", containerPath)).Run()
+	return nil
+}
+
+// ExecInContainerWithStdin runs a shell command in the container, piping stdinData as stdin.
+// This avoids docker cp for input data — much faster for per-test-case runs.
+// The command is wrapped with `timeout` inside the container so it self-terminates
+// cleanly on TLE without killing the container's init process.
+func ExecInContainerWithStdin(cname, shellCmd string, asRoot bool, timeoutMs int, stdinData string) (*ExecuteResult, error) {
+	// Wrap with timeout inside the container (kills the process tree, not PID 1)
+	timeoutSec := (timeoutMs + 999) / 1000 // ceil to seconds
+	wrappedCmd := fmt.Sprintf("timeout -s KILL %d sh -c %s", timeoutSec, shellQuote(shellCmd))
+
+	// Context timeout is a safety net (timeout cmd + 5s grace)
+	deadline := time.Duration(timeoutMs)*time.Millisecond + 5*time.Second
+
+	execArgs := []string{"exec", "-i"} // -i for stdin
+	if asRoot {
+		execArgs = append(execArgs, "-u", "root")
+	}
+	execArgs = append(execArgs, cname, "sh", "-c", wrappedCmd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", execArgs...)
+	cmd.Stdin = strings.NewReader(stdinData)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	start := time.Now()
+	runErr := cmd.Run()
+	elapsed := time.Since(start).Milliseconds()
+
+	stdout := strings.TrimRight(stdoutBuf.String(), "\n")
+	stderr := stderrBuf.String()
+
+	// timeout -s KILL returns exit code 137 (128+9=SIGKILL)
+	// Context deadline exceeded means even the timeout wrapper hung
+	if ctx.Err() == context.DeadlineExceeded {
+		return &ExecuteResult{
+			Stdout: stdout, Stderr: "Time limit exceeded",
+			ExitCode: 124, TimedOut: true, RuntimeMs: elapsed,
+		}, nil
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return nil, fmt.Errorf("docker exec: %w", runErr)
+		}
+	}
+
+	// timeout -s KILL sends SIGKILL → exit code 137
+	// Distinguish TLE (timeout killed) from OOM (Docker killed)
+	if exitCode == 137 {
+		if strings.Contains(stderr, "Killed") && elapsed < int64(timeoutMs)-500 {
+			// Killed well before timeout → likely OOM
+			return &ExecuteResult{
+				Stdout: stdout, Stderr: stderr,
+				ExitCode: exitCode, OOMKilled: true, RuntimeMs: elapsed,
+			}, nil
+		}
+		// Killed near or after timeout → TLE
+		return &ExecuteResult{
+			Stdout: stdout, Stderr: "Time limit exceeded",
+			ExitCode: 124, TimedOut: true, RuntimeMs: elapsed,
+		}, nil
+	}
+
+	oomKilled := exitCode == 137 && strings.Contains(stderr, "Killed")
+
+	return &ExecuteResult{
+		Stdout: stdout, Stderr: stderr,
+		ExitCode: exitCode, TimedOut: false, OOMKilled: oomKilled,
+		RuntimeMs: elapsed,
+	}, nil
+}
+
+// shellQuote wraps a string in single quotes for shell, escaping internal single quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+// ExecInContainer runs a shell command in the given container (no stdin).
+// asRoot=true runs as root (for compile steps), false runs as the default user.
+// Uses `timeout` inside the container to avoid killing PID 1 on TLE.
+func ExecInContainer(cname, shellCmd string, asRoot bool, timeoutMs int) (*ExecuteResult, error) {
+	// Wrap with timeout inside container
+	timeoutSec := (timeoutMs + 999) / 1000
+	wrappedCmd := fmt.Sprintf("timeout -s KILL %d sh -c %s", timeoutSec, shellQuote(shellCmd))
+
+	deadline := time.Duration(timeoutMs)*time.Millisecond + 5*time.Second
+
+	execArgs := []string{"exec"}
+	if asRoot {
+		execArgs = append(execArgs, "-u", "root")
+	}
+	execArgs = append(execArgs, cname, "sh", "-c", wrappedCmd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", execArgs...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	start := time.Now()
+	runErr := cmd.Run()
+	elapsed := time.Since(start).Milliseconds()
+
+	stdout := strings.TrimRight(stdoutBuf.String(), "\n")
+	stderr := stderrBuf.String()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return &ExecuteResult{
+			Stdout: stdout, Stderr: "Time limit exceeded",
+			ExitCode: 124, TimedOut: true, RuntimeMs: elapsed,
+		}, nil
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return nil, fmt.Errorf("docker exec: %w", runErr)
+		}
+	}
+
+	// timeout -s KILL → exit 137. Distinguish TLE from OOM.
+	if exitCode == 137 {
+		if strings.Contains(stderr, "Killed") && elapsed < int64(timeoutMs)-500 {
+			return &ExecuteResult{
+				Stdout: stdout, Stderr: stderr,
+				ExitCode: exitCode, OOMKilled: true, RuntimeMs: elapsed,
+			}, nil
+		}
+		return &ExecuteResult{
+			Stdout: stdout, Stderr: "Time limit exceeded",
+			ExitCode: 124, TimedOut: true, RuntimeMs: elapsed,
+		}, nil
+	}
+
+	oomKilled := exitCode == 137 && strings.Contains(stderr, "Killed")
+
+	return &ExecuteResult{
+		Stdout: stdout, Stderr: stderr,
+		ExitCode: exitCode, TimedOut: false, OOMKilled: oomKilled,
+		RuntimeMs: elapsed,
+	}, nil
+}
+
+// ExecInPool acquires a container, copies files, runs a command, and releases.
+// For simple one-shot executions (the /run endpoint).
+func ExecInPool(image, shellCmd, hostDir string, asRoot bool, timeoutMs, memMB int) (*ExecuteResult, error) {
+	h := AcquireContainer(image, memMB)
+	defer h.Release()
+
+	if err := CopyToContainer(h.Name(), hostDir); err != nil {
+		return nil, err
+	}
+
+	return ExecInContainer(h.Name(), shellCmd, asRoot, timeoutMs)
+}
+
+// isContainerRunning checks if a container is in the "running" state.
+func isContainerRunning(name string) bool {
+	out, err := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", name).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// StopAllPools gracefully stops and removes all pooled containers.
+// Call this on server shutdown.
+func StopAllPools() {
+	poolsMu.Lock()
+	defer poolsMu.Unlock()
+	for _, p := range pools {
+		p.mu.Lock()
+		for _, e := range p.entries {
+			if e != nil {
+				exec.Command("docker", "rm", "-f", e.name).Run()
+			}
+		}
+		p.started = false
+		p.mu.Unlock()
+	}
+	pools = make(map[string]*imagePool)
+	log.Println("[pool] All container pools stopped")
+}

--- a/backend/internal/sandbox/judge.go
+++ b/backend/internal/sandbox/judge.go
@@ -1,10 +1,22 @@
 package sandbox
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+)
+
+// Judge verdict status constants.
+const (
+	StatusAccepted     = "Accepted"
+	StatusWrongAnswer  = "WrongAnswer"
+	StatusRuntimeError = "RuntimeError"
+	StatusCompileError = "CompileError"
+	StatusTLE          = "TimeLimitExceeded"
+	StatusMLE          = "MemoryLimitExceeded"
+	StatusSystemError  = "SystemError"
 )
 
 // JudgeTestCase is a single input/expected-output pair.
@@ -23,25 +35,54 @@ type FailedCase struct {
 	Actual   string `json:"actual,omitempty"`   // stderr for RE/CE, stdout for WA
 }
 
+// CaseResult holds per-test-case output when RunAll mode is used.
+type CaseResult struct {
+	Index  int    `json:"index"`
+	Status string `json:"status"` // "Accepted", "WrongAnswer", "RuntimeError", "TimeLimitExceeded", "MemoryLimitExceeded"
+	Actual string `json:"actual"` // stdout for AC/WA, stderr for RE
+}
+
 // JudgeResult is returned by Judge.
 type JudgeResult struct {
-	Status    string      `json:"status"`               // Accepted | WrongAnswer | RuntimeError | CompileError | TimeLimitExceeded
-	Passed    int         `json:"passed"`
-	Total     int         `json:"total"`
-	RuntimeMs int64       `json:"runtime_ms"`           // slowest test case
-	Failed    *FailedCase `json:"failed_case,omitempty"`
+	Status    string        `json:"status"`               // Accepted | WrongAnswer | RuntimeError | CompileError | TimeLimitExceeded | MemoryLimitExceeded | SystemError
+	Passed    int           `json:"passed"`
+	Total     int           `json:"total"`
+	RuntimeMs int64         `json:"runtime_ms"`           // slowest test case
+	MemoryKB  int64         `json:"memory_kb,omitempty"`  // peak memory (when available)
+	Failed    *FailedCase   `json:"failed_case,omitempty"`
+	AllCases  []CaseResult  `json:"all_cases,omitempty"`  // populated when RunAll=true
+}
+
+// JudgeAll evaluates user code against ALL test cases without short-circuiting.
+// Returns per-case results so callers can fix all failures at once.
+func JudgeAll(lang, code string, testCases []JudgeTestCase, timeLimit, memMB int) (*JudgeResult, error) {
+	return judgeInternal(lang, code, testCases, timeLimit, memMB, true)
 }
 
 // Judge evaluates user code against all test cases.
-//
-// Strategy:
-//   - Compiled languages (cfg.CompileCmd != ""): compile once with a writable
-//     mount so the binary lands on the host tmpDir, then run each test case
-//     read-only — no redundant recompilation.
-//   - Interpreted languages: run each test case directly (no compile phase).
-//
 // Short-circuits on the first failure and never reveals subsequent test cases.
 func Judge(lang, code string, testCases []JudgeTestCase, timeLimit, memMB int) (*JudgeResult, error) {
+	return judgeInternal(lang, code, testCases, timeLimit, memMB, false)
+}
+
+// batchOutputDelim separates test case outputs in batch stdout.
+const batchOutputDelim = "<<<GATECODE_OUT_SEP>>>"
+
+// batchCaseResult is the JSON structure emitted by the batch runner per case.
+type batchCaseResult struct {
+	Exit   int    `json:"x"`
+	Stdout string `json:"o"`
+	Stderr string `json:"e"`
+	Ms     int64  `json:"t"`
+}
+
+// judgeInternal is the shared implementation for Judge and JudgeAll.
+//
+// Optimized Strategy — Minimal Docker CLI calls:
+//   1. docker cp: source + all inputs + runner script → /w
+//   2. docker exec: chmod + compile + run ALL test cases (one single call)
+//   This means only 2 Docker CLI calls total (eliminating ~300ms overhead).
+func judgeInternal(lang, code string, testCases []JudgeTestCase, timeLimit, memMB int, runAll bool) (*JudgeResult, error) {
 	if timeLimit <= 0 {
 		timeLimit = DefaultTimeLimit
 	}
@@ -58,7 +99,7 @@ func Judge(lang, code string, testCases []JudgeTestCase, timeLimit, memMB int) (
 		return nil, fmt.Errorf("unsupported language: %s", lang)
 	}
 
-	// ── Workspace ────────────────────────────────────────────────────────────
+	// ── Host workspace ──────────────────────────────────────────────────────
 	tmpDir, err := os.MkdirTemp("/tmp", "judge_*")
 	if err != nil {
 		return nil, fmt.Errorf("mktemp: %w", err)
@@ -71,90 +112,259 @@ func Judge(lang, code string, testCases []JudgeTestCase, timeLimit, memMB int) (
 		return nil, fmt.Errorf("chmod: %w", err)
 	}
 
-	// Write wrapped source code once
+	// Write wrapped source code
 	wrapped := WrapCode(lang, code)
 	if err := os.WriteFile(filepath.Join(tmpDir, cfg.FileName), []byte(wrapped), 0644); err != nil {
 		return nil, fmt.Errorf("write source: %w", err)
 	}
 
-	result := &JudgeResult{Total: len(testCases)}
-
-	// ── Compile phase (compiled languages only) ───────────────────────────────
-	// Mount as rw so the binary is written to tmpDir on the host.
-	// CompileCmd uses /w/prog as the output path (e.g. g++ -o /w/prog …),
-	// which resolves to tmpDir/prog after the bind mount.
-	if cfg.CompileCmd != "" {
-		compileMem := memMB
-		if cfg.CompileMemMB > 0 {
-			compileMem = cfg.CompileMemMB
-		}
-		res, err := dockerRun(cfg.Image, cfg.CompileCmd, tmpDir, true, 30_000, compileMem)
-		if err != nil {
-			return nil, fmt.Errorf("compile container: %w", err)
-		}
-		if res.ExitCode != 0 {
-			return &JudgeResult{
-				Status: "CompileError",
-				Total:  result.Total,
-				Failed: &FailedCase{Index: -1, Actual: res.Stderr},
-			}, nil
+	// Write per-case input files on host
+	for i, tc := range testCases {
+		fname := fmt.Sprintf("_in_%d", i)
+		if err := os.WriteFile(filepath.Join(tmpDir, fname), []byte(tc.Input), 0644); err != nil {
+			return nil, fmt.Errorf("write input %d: %w", i, err)
 		}
 	}
 
-	// ── Per-test-case run ─────────────────────────────────────────────────────
+	// Write the unified runner script (chmod + compile + run all cases)
+	script := buildUnifiedScript(cfg.CompileCmd, cfg.RunCmd, len(testCases), timeLimit)
+	if err := os.WriteFile(filepath.Join(tmpDir, "_runner.sh"), []byte(script), 0755); err != nil {
+		return nil, fmt.Errorf("write runner script: %w", err)
+	}
+
+	result := &JudgeResult{Total: len(testCases)}
+
+	// ── Acquire container ───────────────────────────────────────────────────
+	execMem := memMB
+	if cfg.CompileMemMB > execMem {
+		execMem = cfg.CompileMemMB
+	}
+	h := AcquireContainer(cfg.Image, execMem)
+	defer h.Release()
+	cname := h.Name()
+
+	// ── Docker call 1: copy files ───────────────────────────────────────────
+	if err := CopyToContainerFast(cname, tmpDir); err != nil {
+		return &JudgeResult{
+			Status: StatusSystemError,
+			Total:  result.Total,
+			Failed: &FailedCase{Index: -1, Actual: fmt.Sprintf("copy to container: %v", err)},
+		}, nil
+	}
+
+	// ── Docker call 2: chmod + compile + run ALL cases in ONE exec ──────────
+	totalTimeout := timeLimit*len(testCases) + 30_000 // compile time + all cases + grace
+	batchRes, err := ExecInContainer(cname, "sh /w/_runner.sh", true, totalTimeout)
+	if err != nil {
+		return &JudgeResult{
+			Status: StatusSystemError,
+			Total:  result.Total,
+			Failed: &FailedCase{Index: -1, Actual: fmt.Sprintf("batch exec error: %v", err)},
+		}, nil
+	}
+
+	// Check for compile error (runner script outputs CE marker)
+	if strings.HasPrefix(batchRes.Stdout, "<<<GATECODE_CE>>>") {
+		ceMsg := strings.TrimPrefix(batchRes.Stdout, "<<<GATECODE_CE>>>")
+		ceMsg = strings.TrimSpace(ceMsg)
+		if ceMsg == "" {
+			ceMsg = batchRes.Stderr
+		}
+		return &JudgeResult{
+			Status: StatusCompileError,
+			Total:  result.Total,
+			Failed: &FailedCase{Index: -1, Actual: ceMsg},
+		}, nil
+	}
+
+	return parseBatchOutput(batchRes.Stdout, testCases, cfg.IsAutoWrap, runAll)
+}
+
+// buildUnifiedScript generates ONE shell script that does:
+//   1. chmod (fix permissions from docker cp)
+//   2. compile (if needed)
+//   3. run all test cases with per-case timeout
+// This is the ONLY docker exec call needed after docker cp.
+func buildUnifiedScript(compileCmd, runCmd string, numCases, timeLimitMs int) string {
+	timeoutSec := (timeLimitMs + 999) / 1000
+
+	var sb strings.Builder
+	sb.WriteString("#!/bin/sh\nset -u\n")
+
+	// Phase 1: fix permissions
+	sb.WriteString("chmod -R 755 /w\n")
+
+	// Phase 2: compile (if needed)
+	if compileCmd != "" {
+		// Capture compile stderr; output CE marker if compilation fails
+		sb.WriteString(fmt.Sprintf(`
+_ce=$(%s 2>&1)
+if [ $? -ne 0 ]; then
+  printf '<<<GATECODE_CE>>>%%s\n' "$_ce"
+  exit 0
+fi
+`, compileCmd))
+	}
+
+	// Phase 3: run all test cases
+	// Outputs per case: JSON line {x:exitcode, t:ms, o:stdout, e:stderr}
+	// Cases separated by <<<GATECODE_OUT_SEP>>>
+	sb.WriteString(fmt.Sprintf(`
+TL=%d
+RUN_CMD=%s
+N=%d
+i=0
+while [ "$i" -lt "$N" ]; do
+  IN_FILE="/w/_in_$i"
+  [ ! -f "$IN_FILE" ] && IN_FILE="/dev/null"
+  OUT_FILE="/tmp/_out_$i"
+  ERR_FILE="/tmp/_err_$i"
+
+  START_NS=$(date +%%s%%N 2>/dev/null || echo 0)
+  timeout -s KILL "$TL" sh -c "$RUN_CMD" < "$IN_FILE" > "$OUT_FILE" 2> "$ERR_FILE"
+  EC=$?
+  END_NS=$(date +%%s%%N 2>/dev/null || echo 0)
+  MS=$(( (END_NS - START_NS) / 1000000 ))
+  [ "$MS" -lt 0 ] && MS=0
+
+  # Encode stdout/stderr as JSON strings using awk (no subprocess spawn)
+  O_JSON=$(awk 'BEGIN{ORS=""} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); gsub(/\t/,"\\t"); gsub(/\r/,"\\r"); if(NR>1) printf "\\n"; printf "%%s",$0}' "$OUT_FILE" 2>/dev/null)
+  E_JSON=$(awk 'BEGIN{ORS=""} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); gsub(/\t/,"\\t"); gsub(/\r/,"\\r"); if(NR>1) printf "\\n"; printf "%%s",$0}' "$ERR_FILE" 2>/dev/null)
+
+  printf '{"x":%%d,"t":%%d,"o":"%%s","e":"%%s"}\n' "$EC" "$MS" "$O_JSON" "$E_JSON"
+  [ "$i" -lt "$((N-1))" ] && printf '<<<GATECODE_OUT_SEP>>>\n'
+
+  rm -f "$OUT_FILE" "$ERR_FILE"
+  i=$((i + 1))
+done
+`, timeoutSec, shellQuote(runCmd), numCases))
+
+	return sb.String()
+}
+
+// parseBatchOutput parses the stdout from the batch runner script into a JudgeResult.
+func parseBatchOutput(stdout string, testCases []JudgeTestCase, isAutoWrap, runAll bool) (*JudgeResult, error) {
+	result := &JudgeResult{Total: len(testCases)}
+
+	parts := strings.Split(stdout, batchOutputDelim)
+
 	var maxRT int64
+	var firstFailed *FailedCase
+	var allCases []CaseResult
+
+	if runAll {
+		allCases = make([]CaseResult, 0, len(testCases))
+	}
+
 	for i, tc := range testCases {
-		// Overwrite input.txt for this test case
-		if err := os.WriteFile(filepath.Join(tmpDir, "input.txt"), []byte(tc.Input), 0644); err != nil {
-			return nil, fmt.Errorf("write input[%d]: %w", i, err)
+		if i >= len(parts) {
+			status := StatusSystemError
+			actual := "no output from batch runner"
+			if !runAll {
+				result.Status = status
+				result.Failed = &FailedCase{Index: i, Input: tc.Input, Actual: actual}
+				result.RuntimeMs = maxRT
+				return result, nil
+			}
+			allCases = append(allCases, CaseResult{Index: i, Status: status, Actual: actual})
+			if firstFailed == nil {
+				result.Status = status
+				firstFailed = &FailedCase{Index: i, Input: tc.Input, Actual: actual}
+			}
+			continue
 		}
 
-		// Run with read-only mount: binary/source at /w, input at /w/input.txt
-		shellCmd := cfg.RunCmd + " < /w/input.txt"
-		res, err := dockerRun(cfg.Image, shellCmd, tmpDir, false, timeLimit, memMB)
-		if err != nil {
-			return nil, fmt.Errorf("run container[%d]: %w", i, err)
-		}
-		if res.RuntimeMs > maxRT {
-			maxRT = res.RuntimeMs
+		raw := strings.TrimSpace(parts[i])
+		var cr batchCaseResult
+		if err := json.Unmarshal([]byte(raw), &cr); err != nil {
+			if !runAll {
+				result.Status = StatusSystemError
+				result.Failed = &FailedCase{Index: i, Actual: fmt.Sprintf("parse batch output: %v (raw: %s)", err, truncate(raw, 200))}
+				result.RuntimeMs = maxRT
+				return result, nil
+			}
+			allCases = append(allCases, CaseResult{Index: i, Status: StatusSystemError, Actual: fmt.Sprintf("parse error: %v", err)})
+			continue
 		}
 
-		// TLE
-		if res.TimedOut {
-			result.Status = "TimeLimitExceeded"
-			result.Failed = &FailedCase{Index: i, Input: tc.Input}
-			result.RuntimeMs = maxRT
-			return result, nil
+		if cr.Ms > maxRT {
+			maxRT = cr.Ms
+		}
+
+		// TLE: timeout -s KILL returns exit code 137, timeout returns 124
+		if cr.Exit == 137 || cr.Exit == 124 {
+			if !runAll {
+				result.Status = StatusTLE
+				result.Failed = &FailedCase{Index: i, Input: tc.Input}
+				result.RuntimeMs = maxRT
+				return result, nil
+			}
+			allCases = append(allCases, CaseResult{Index: i, Status: StatusTLE})
+			if firstFailed == nil {
+				result.Status = StatusTLE
+				firstFailed = &FailedCase{Index: i, Input: tc.Input}
+			}
+			continue
 		}
 
 		// Runtime error
-		if res.ExitCode != 0 {
-			result.Status = "RuntimeError"
-			result.Failed = &FailedCase{
-				Index: i, Input: tc.Input,
-				Expected: tc.Expected, Actual: res.Stderr,
+		if cr.Exit != 0 {
+			if !runAll {
+				result.Status = StatusRuntimeError
+				result.Failed = &FailedCase{Index: i, Input: tc.Input, Expected: tc.Expected, Actual: cr.Stderr}
+				result.RuntimeMs = maxRT
+				return result, nil
 			}
-			result.RuntimeMs = maxRT
-			return result, nil
+			allCases = append(allCases, CaseResult{Index: i, Status: StatusRuntimeError, Actual: cr.Stderr})
+			if firstFailed == nil {
+				result.Status = StatusRuntimeError
+				firstFailed = &FailedCase{Index: i, Input: tc.Input, Expected: tc.Expected, Actual: cr.Stderr}
+			}
+			continue
 		}
 
-		actual := strings.TrimRight(res.Stdout, "\n")
+		actual := strings.TrimRight(cr.Stdout, "\n")
 
-		// Wrong answer (skip if expected output not yet imported)
-		if tc.Expected != "" && !OutputEqual(cfg.IsAutoWrap, actual, tc.Expected) {
-			result.Status = "WrongAnswer"
-			result.Failed = &FailedCase{
-				Index: i, Input: tc.Input,
-				Expected: tc.Expected, Actual: actual,
+		// Wrong answer
+		if tc.Expected != "" && !OutputEqual(isAutoWrap, actual, tc.Expected) {
+			if !runAll {
+				result.Status = StatusWrongAnswer
+				result.Failed = &FailedCase{Index: i, Input: tc.Input, Expected: tc.Expected, Actual: actual}
+				result.RuntimeMs = maxRT
+				return result, nil
 			}
-			result.RuntimeMs = maxRT
-			return result, nil
+			allCases = append(allCases, CaseResult{Index: i, Status: StatusWrongAnswer, Actual: actual})
+			if firstFailed == nil {
+				result.Status = StatusWrongAnswer
+				firstFailed = &FailedCase{Index: i, Input: tc.Input, Expected: tc.Expected, Actual: actual}
+			}
+			continue
 		}
 
 		result.Passed++
+		if runAll {
+			allCases = append(allCases, CaseResult{Index: i, Status: StatusAccepted, Actual: actual})
+		}
 	}
 
-	result.Status = "Accepted"
+	if firstFailed != nil {
+		result.Failed = firstFailed
+		result.RuntimeMs = maxRT
+		result.AllCases = allCases
+		return result, nil
+	}
+
+	result.Status = StatusAccepted
 	result.RuntimeMs = maxRT
+	if runAll {
+		result.AllCases = allCases
+	}
 	return result, nil
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }

--- a/frontend/src/components/MultiLangSolution/MultiLangSolution.tsx
+++ b/frontend/src/components/MultiLangSolution/MultiLangSolution.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { cpp } from "@codemirror/lang-cpp";
+import { java } from "@codemirror/lang-java";
+import { python } from "@codemirror/lang-python";
+import { go } from "@codemirror/lang-go";
+import { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { SolutionEntry } from "@/utils/types/problem";
+
+type MultiLangSolutionProps = {
+	problemSlug: string;
+	solutions?: SolutionEntry[];
+};
+
+const langExtensionMap: Record<string, () => Extension> = {
+	cpp: () => cpp(),
+	java: () => java(),
+	python3: () => python(),
+	python: () => python(),
+	go: () => go(),
+};
+
+const MultiLangSolution: React.FC<MultiLangSolutionProps> = ({ problemSlug, solutions }) => {
+	const data = solutions ?? [];
+	const [activeIdx, setActiveIdx] = useState(0);
+
+	if (data.length === 0) {
+		return (
+			<div className="flex items-center justify-center py-12 text-gray-400 text-sm">
+				Solutions coming soon
+			</div>
+		);
+	}
+
+	const active = data[activeIdx];
+	const ext = langExtensionMap[active.langKey];
+
+	const [copied, setCopied] = useState(false);
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(active.code);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {}
+	};
+
+	return (
+		<div>
+			{/* Language tabs */}
+			<div className="flex border-b border-dark-divider-border-2">
+				{data.map((sol, idx) => (
+					<button
+						key={sol.langKey}
+						onClick={() => setActiveIdx(idx)}
+						className={`px-4 py-2 text-sm font-medium transition-colors ${
+							idx === activeIdx
+								? "border-b-2 border-brand-orange text-brand-orange"
+								: "text-gray-500 hover:text-gray-700"
+						}`}
+					>
+						{sol.language}
+					</button>
+				))}
+			</div>
+
+			{/* Code viewer */}
+			<div className="relative mt-2">
+				<button
+					onClick={handleCopy}
+					className="absolute top-2 right-2 z-10 bg-dark-fill-3 hover:bg-dark-fill-2 text-gray-600 px-2 py-1 rounded text-xs transition-colors"
+				>
+					{copied ? "Copied" : "Copy"}
+				</button>
+				<CodeMirror
+					value={active.code}
+					extensions={[
+						...(ext ? [ext()] : []),
+						EditorView.editable.of(false),
+						EditorView.lineWrapping,
+					]}
+					readOnly={true}
+					theme="light"
+					basicSetup={{
+						lineNumbers: true,
+						foldGutter: false,
+						highlightActiveLine: false,
+					}}
+					className="text-sm border border-dark-divider-border-2 rounded-lg overflow-hidden"
+				/>
+			</div>
+
+			{/* Complexity info */}
+			{(active.timeComplexity || active.spaceComplexity) && (
+				<div className="flex gap-6 mt-3 text-xs text-gray-500">
+					{active.timeComplexity && (
+						<span>
+							<span className="font-medium text-gray-700">时间复杂度:</span> {active.timeComplexity}
+						</span>
+					)}
+					{active.spaceComplexity && (
+						<span>
+							<span className="font-medium text-gray-700">空间复杂度:</span> {active.spaceComplexity}
+						</span>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default MultiLangSolution;

--- a/frontend/src/pages/problems/[pid].tsx
+++ b/frontend/src/pages/problems/[pid].tsx
@@ -1,18 +1,92 @@
+import "katex/dist/katex.min.css";
 import Topbar from "@/components/Topbar/Topbar";
 import Workspace from "@/components/Workspace/Workspace";
 import useHasMounted from "@/hooks/useHasMounted";
 import { problems as localProblems } from "@/utils/problems";
 import { BackendProblemDetail, Problem } from "@/utils/types/problem";
-import { GetServerSideProps } from "next";
-import React from "react";
+import { GetStaticPaths, GetStaticProps } from "next";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 
-type ProblemPageProps = {
-	problem: Problem;
-};
-
-const ProblemPage: React.FC<ProblemPageProps> = ({ problem }) => {
+const ProblemPage: React.FC = () => {
 	const hasMounted = useHasMounted();
-	if (!hasMounted) return null;
+	const router = useRouter();
+	const pid = router.query.pid as string | undefined;
+	const [problem, setProblem] = useState<Problem | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		if (!pid) return;
+
+		const localProblem = localProblems[pid];
+		const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8081";
+
+		// Fetch from backend (with timeout)
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), 5000);
+
+		fetch(`${backendUrl}/api/v1/problems/${pid}`, { signal: controller.signal })
+			.then((res) => (res.ok ? res.json() : null))
+			.catch(() => null)
+			.then((backendProblem: BackendProblemDetail | null) => {
+				clearTimeout(timer);
+				const templateCodeMap: Record<string, string> = backendProblem?.template_code ?? {};
+
+				if (localProblem) {
+					setProblem({
+						...localProblem,
+						handlerFunction: localProblem.handlerFunction.toString(),
+						templateCodeMap,
+						solutions: backendProblem?.solutions ?? undefined,
+						editorial: backendProblem?.editorial ?? undefined,
+					});
+				} else if (backendProblem) {
+					const starterCode =
+						templateCodeMap["javascript"] ??
+						templateCodeMap["python3"] ??
+						templateCodeMap[Object.keys(templateCodeMap)[0]] ??
+						"// 暂无模板代码";
+
+					setProblem({
+						id: backendProblem.slug,
+						title: `${backendProblem.frontend_question_id}. ${backendProblem.title}`,
+						problemStatement: backendProblem.content,
+						examples: [],
+						constraints: "",
+						order: backendProblem.frontend_question_id,
+						difficulty: backendProblem.difficulty,
+						starterCode,
+						handlerFunction: "",
+						starterFunctionName: "",
+						templateCodeMap,
+						solutions: backendProblem.solutions ?? undefined,
+						editorial: backendProblem.editorial ?? undefined,
+					});
+				} else {
+					router.replace("/404");
+					return;
+				}
+				setLoading(false);
+			});
+
+		return () => {
+			clearTimeout(timer);
+			controller.abort();
+		};
+	}, [pid]);
+
+	if (!hasMounted || !pid) return null;
+
+	if (loading || !problem) {
+		return (
+			<div>
+				<Topbar problemPage />
+				<div className='flex items-center justify-center h-[calc(100vh-50px)]'>
+					<div className='animate-pulse text-gray-400 text-sm'>Loading problem...</div>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div>
@@ -23,61 +97,13 @@ const ProblemPage: React.FC<ProblemPageProps> = ({ problem }) => {
 };
 export default ProblemPage;
 
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
-	const pid = params?.pid as string;
-	const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8081";
+// Static shell with fallback — no server round-trip after first visit.
+// Data is fetched client-side in the useEffect above.
+export const getStaticPaths: GetStaticPaths = async () => ({
+	paths: [],
+	fallback: "blocking",
+});
 
-	// 先从后端拉一次，获取所有语言的 template_code（本地题目也需要）
-	let backendProblem: BackendProblemDetail | null = null;
-	try {
-		const res = await fetch(`${backendUrl}/api/v1/problems/${pid}`);
-		if (res.ok) {
-			backendProblem = await res.json();
-		}
-	} catch {
-		// 后端不可用时降级
-	}
-
-	const templateCodeMap: Record<string, string> = backendProblem?.template_code ?? {};
-
-	// 优先使用本地题目（含 handlerFunction，支持本地测试）
-	const localProblem = localProblems[pid];
-	if (localProblem) {
-		return {
-			props: {
-				problem: {
-					...localProblem,
-					handlerFunction: localProblem.handlerFunction.toString(),
-					templateCodeMap,
-				},
-			},
-		};
-	}
-
-	// 纯后端题目
-	if (!backendProblem) {
-		return { notFound: true };
-	}
-
-	const starterCode =
-		templateCodeMap["javascript"] ??
-		templateCodeMap["python3"] ??
-		templateCodeMap[Object.keys(templateCodeMap)[0]] ??
-		"// 暂无模板代码";
-
-	const problem: Problem = {
-		id: backendProblem.slug,
-		title: `${backendProblem.frontend_question_id}. ${backendProblem.title}`,
-		problemStatement: backendProblem.content,
-		examples: [],
-		constraints: "",
-		order: backendProblem.frontend_question_id,
-		difficulty: backendProblem.difficulty,
-		starterCode,
-		handlerFunction: "",
-		starterFunctionName: "",
-		templateCodeMap,
-	};
-
-	return { props: { problem } };
-};
+export const getStaticProps: GetStaticProps = async () => ({
+	props: {},
+});

--- a/frontend/src/utils/types/problem.ts
+++ b/frontend/src/utils/types/problem.ts
@@ -19,6 +19,8 @@ export type Problem = {
 	handlerFunction: ((fn: any) => boolean) | string;
 	starterFunctionName: string;
 	templateCodeMap?: Record<string, string>;
+	solutions?: SolutionEntry[];
+	editorial?: string;
 };
 
 export type DBProblem = {
@@ -52,4 +54,63 @@ export type BackendProblemDetail = {
 	template_code: Record<string, string> | null;
 	is_vip_only: boolean;
 	is_acm_mode: boolean;
+	solutions: SolutionEntry[] | null;
+	editorial: string | null;
+};
+
+export type Tag = {
+	id: string;
+	name: string;
+	type: "topic" | "company" | "position";
+	is_vip_only: boolean;
+};
+
+export type CurriculumProblem = {
+	id: number;
+	title: string;
+	slug: string;
+	difficulty: "Easy" | "Medium" | "Hard";
+	is_vip_only: boolean;
+};
+
+export type SubModule = {
+	id: string;
+	title: string;
+	problems: CurriculumProblem[];
+	is_vip_only: boolean;
+};
+
+export type Module = {
+	id: string;
+	title: string;
+	description: string;
+	subModules: SubModule[];
+	is_vip_only: boolean;
+};
+
+export type Collection = {
+	id: string;
+	title: string;
+	description: string;
+	cover_image: string;
+	difficulty_level: "Beginner" | "Intermediate" | "Advanced";
+	problems: CurriculumProblem[];
+	is_vip_only: boolean;
+};
+
+export type SolutionEntry = {
+	language: string;
+	langKey: string;
+	code: string;
+	timeComplexity?: string;
+	spaceComplexity?: string;
+};
+
+export type TopicAbility = {
+	topic: string;
+	shortLabel: string;
+	score: number;
+	totalProblems: number;
+	solvedProblems: number;
+	passRate: number;
 };

--- a/scripts/populate_solutions.py
+++ b/scripts/populate_solutions.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Populate problems.solutions and problems.editorial from solution repos.
+
+Reads C++/Java/Python3 code from Sol1/Sol2, extracts editorial from
+README_EN.md (between <!-- solution:start --> and <!-- tabs:start -->),
+and writes JSON to MySQL.
+
+Usage:
+    python3 populate_solutions.py                  # dry-run (print stats)
+    python3 populate_solutions.py --write          # actually write to DB
+    python3 populate_solutions.py --write --pid 1  # single problem
+"""
+
+import argparse
+import json
+import re
+import pymysql
+import sys
+from pathlib import Path
+
+SOL1_BASE = Path("/Users/capsfly/Desktop/gatecode/leetcode solution/solution 1/solution")
+SOL2_BASE = Path("/Users/capsfly/Desktop/gatecode/leetcode solution/solution 2")
+
+# language -> (langKey for frontend, file extension, Sol1 filename, Sol2 subdirectory)
+LANGUAGES = {
+    "C++":     {"langKey": "cpp",     "ext": ".cpp",  "sol1_file": "Solution.cpp",  "sol2_dir": "C++"},
+    "Java":    {"langKey": "java",    "ext": ".java", "sol1_file": "Solution.java", "sol2_dir": "Java"},
+    "Python3": {"langKey": "python3", "ext": ".py",   "sol1_file": "Solution.py",   "sol2_dir": "Python"},
+}
+
+
+def find_sol1_dir(pid: int) -> Path | None:
+    """Find the Sol1 problem directory (e.g., 0000-0099/0001.Two Sum/)."""
+    rng = f"{pid // 100 * 100:04d}-{pid // 100 * 100 + 99:04d}"
+    parent = SOL1_BASE / rng
+    if not parent.exists():
+        return None
+    prefix = f"{pid:04d}."
+    for d in parent.iterdir():
+        if d.is_dir() and d.name.startswith(prefix):
+            return d
+    return None
+
+
+def read_solution_code(pid: int, slug: str, lang_info: dict) -> str | None:
+    """Try to read solution code from Sol1 first, then Sol2."""
+    # Sol1: structured directory
+    sol1_dir = find_sol1_dir(pid)
+    if sol1_dir:
+        f = sol1_dir / lang_info["sol1_file"]
+        if f.exists():
+            code = f.read_text(errors="replace").strip()
+            if len(code) > 20:
+                return code
+
+    # Sol2: flat by language, slug-based filenames
+    sol2_file = SOL2_BASE / lang_info["sol2_dir"] / f"{slug}{lang_info['ext']}"
+    if sol2_file.exists():
+        code = sol2_file.read_text(errors="replace").strip()
+        if len(code) > 20:
+            return code
+
+    return None
+
+
+def extract_editorial(pid: int) -> str | None:
+    """Extract editorial text from README_EN.md.
+
+    Grabs content between <!-- solution:start --> and <!-- tabs:start -->.
+    This is the explanation text before the code blocks.
+    """
+    sol1_dir = find_sol1_dir(pid)
+    if not sol1_dir:
+        return None
+
+    readme = sol1_dir / "README_EN.md"
+    if not readme.exists():
+        return None
+
+    content = readme.read_text(errors="replace")
+
+    # Extract between <!-- solution:start --> and <!-- tabs:start -->
+    m = re.search(
+        r'<!--\s*solution:start\s*-->(.*?)<!--\s*tabs:start\s*-->',
+        content,
+        re.DOTALL,
+    )
+    if not m:
+        return None
+
+    editorial = m.group(1).strip()
+
+    # Remove the "### Solution 1:" header prefix if it's the only solution
+    # Keep it if there are multiple solutions
+    # Skip stub editorials that are just a header with no real explanation
+    if editorial and len(editorial) > 30:
+        return editorial
+
+    return None
+
+
+def build_solutions_json(pid: int, slug: str) -> list[dict] | None:
+    """Build the solutions JSON array for a problem."""
+    entries = []
+    for lang_name, lang_info in LANGUAGES.items():
+        code = read_solution_code(pid, slug, lang_info)
+        if code:
+            entries.append({
+                "language": lang_name,
+                "langKey": lang_info["langKey"],
+                "code": code,
+            })
+
+    return entries if entries else None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Populate solutions/editorial into DB")
+    parser.add_argument("--write", action="store_true", help="Actually write to DB (default is dry-run)")
+    parser.add_argument("--pid", type=int, help="Process only this frontend_question_id")
+    parser.add_argument("--host", default="127.0.0.1", help="MySQL host")
+    parser.add_argument("--port", type=int, default=3306)
+    parser.add_argument("--user", default="root")
+    parser.add_argument("--password", default="")
+    parser.add_argument("--db", default="gatecode")
+    args = parser.parse_args()
+
+    conn = pymysql.connect(
+        host=args.host, port=args.port, user=args.user,
+        password=args.password, database=args.db,
+        charset="utf8mb4",
+    )
+    cur = conn.cursor()
+
+    # Fetch all problems
+    if args.pid:
+        cur.execute(
+            "SELECT frontend_question_id, slug FROM problems WHERE frontend_question_id = %s",
+            (args.pid,),
+        )
+    else:
+        cur.execute("SELECT frontend_question_id, slug FROM problems ORDER BY frontend_question_id")
+
+    rows = cur.fetchall()
+    print(f"Processing {len(rows)} problems...")
+
+    stats = {"solutions": 0, "editorial": 0, "skipped": 0, "no_code": 0}
+
+    for i, (pid, slug) in enumerate(rows):
+        solutions = build_solutions_json(pid, slug)
+        editorial = extract_editorial(pid)
+
+        if not solutions and not editorial:
+            stats["no_code"] += 1
+            continue
+
+        if solutions:
+            stats["solutions"] += 1
+        if editorial:
+            stats["editorial"] += 1
+
+        if args.write:
+            sol_json = json.dumps(solutions, ensure_ascii=False) if solutions else None
+            cur.execute(
+                "UPDATE problems SET solutions = %s, editorial = %s WHERE frontend_question_id = %s",
+                (sol_json, editorial, pid),
+            )
+
+        if (i + 1) % 500 == 0:
+            if args.write:
+                conn.commit()
+            print(f"  [{i+1}/{len(rows)}] solutions={stats['solutions']}, editorial={stats['editorial']}")
+
+    if args.write:
+        conn.commit()
+
+    print(f"\nDone! Processed {len(rows)} problems.")
+    print(f"  Solutions found: {stats['solutions']}")
+    print(f"  Editorial found: {stats['editorial']}")
+    print(f"  No code found:   {stats['no_code']}")
+    if not args.write:
+        print("\n  (DRY RUN — pass --write to actually update the DB)")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. Solution & Editorial pipeline (DB → API → Frontend):
   - Backend: add `solutions` (JSON) and `editorial` (MEDIUMTEXT) columns to Problem model
   - Frontend types: extend BackendProblemDetail and Problem with solutions/editorial
   - [pid].tsx: wire solutions/editorial from API into Problem state
   - ProblemDescription: render editorial via MathRenderer in Solution tab
   - MultiLangSolution: consume real data, remove mock fallback, show "coming soon" when empty
   - populate_solutions.py: batch script reads C++/Java/Python3 from Sol1/Sol2 repos, extracts editorial from README_EN.md, writes to MySQL (3521 solutions, 2719 editorials)

2. Judge performance optimization (4-6x speedup):
   - Unified docker exec: merge chmod + compile + run ALL test cases into a single `docker exec` call (was 3 + N separate calls), eliminates ~170ms CLI overhead per case
   - CopyToContainerFast: bare `docker cp` with no extra exec (chmod moved into runner script)
   - Batch runner script: awk-based JSON encoding replaces python3 subprocess per test case
   - Skip docker inspect on pool acquire (lazy health check on failure only)
   - Container pool extracted to container_pool.go

3. Frontend UX:
   - Non-blocking Firebase write on Accepted (fire-and-forget updateDoc)
   - Copy button shows inline "Copied" feedback instead of toast notification

Benchmarks (20 test cases, warm pool):
  C++:     ~5s → ~1.1s (4.5x faster)
  Python3: ~4.5s → ~0.72s (6.3x faster)
  Java:    ~7s → ~2.3s (3x faster)